### PR TITLE
Set x_callback to a null string when no x_success

### DIFF
--- a/api.py
+++ b/api.py
@@ -20,6 +20,8 @@ class WorkingCopyApi():
 		if 'x_success' in payload:
 			payload['x-success'] = payload.pop('x_success')
 			x_callback = 'x-callback-url/'
+		else:
+			x_callback = ''
 		
 		payload['key'] = self.key
 		if action == 'read':


### PR DESCRIPTION
Avoid an exception when there is no x_success set - e.g. when the
action is 'open', to view a repo in WC.